### PR TITLE
fix: update recent activity action version

### DIFF
--- a/.github/workflows/recent-activity.yml
+++ b/.github/workflows/recent-activity.yml
@@ -1,6 +1,7 @@
+---
 name: Update recent activity
 
-on:
+'on':
   schedule:
     - cron: "31 6 * * *"  # daily at 06:31 UTC
   workflow_dispatch:
@@ -13,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Recent activity
-        uses: Readme-Workflows/recent-activity@v2.6.3
+        uses: Readme-Workflows/recent-activity@v2.4.1
         with:
           GH_USERNAME: Jason-Latz
 


### PR DESCRIPTION
## Summary
- use latest published release tag for recent activity workflow
- quote `on` key and add YAML document start for linting

## Testing
- `yamllint .github/workflows/recent-activity.yml`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a54643646c832cafe95658745770c0