### PR TITLE
[codex] Restore recent activity markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ I'm a Northwestern student studying Computer Science and Psychology! After worki
 
 ---
 
+## 📌 Recent GitHub Activity
+<!--RECENT_ACTIVITY:start-->
+<!--RECENT_ACTIVITY:end-->
 
 ---
 


### PR DESCRIPTION
## Summary
- restore the `Recent GitHub Activity` heading and `RECENT_ACTIVITY` marker comments in `README.md`
- keep the fix isolated to the three lines the scheduled workflow requires

## Evidence
- GitHub Actions run `26679507693` on `main` failed on 2026-05-30 with `Couldn't find the <!--RECENT_ACTIVITY:start--> comment. Exiting!`
- `main` `README.md` currently has no `RECENT_ACTIVITY` markers
- existing PR #8 also restores the markers, but its branch now carries broader weekly-work-log README changes; this PR isolates the workflow fix for easier merge

## Validation
- `rg -n "RECENT_ACTIVITY:start|RECENT_ACTIVITY:end|Recent GitHub Activity" README.md`
- `git diff --check`