### PR TITLE
chore: restore daily profile updates

### DIFF
--- a/.github/workflows/activity-graph.yml
+++ b/.github/workflows/activity-graph.yml
@@ -2,7 +2,7 @@ name: GitHub-Profile-3D-Contrib
 
 on:
   schedule: # 03:00 JST == 18:00 UTC
-    - cron: "0 18 * * 0"
+    - cron: "0 18 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/activity-graph.yml
+++ b/.github/workflows/activity-graph.yml
@@ -2,7 +2,7 @@ name: GitHub-Profile-3D-Contrib
 
 on:
   schedule: # 03:00 JST == 18:00 UTC
-    - cron: "0 18 * * *"
+    - cron: "0 18 * * 0"
   workflow_dispatch:
 
 permissions:
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: yoshi389111/github-profile-3d-contrib@latest
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # Prefer the PAT secret so the graph can include private contributions.
+          GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}
           USERNAME: ${{ github.repository_owner }}
       - name: Commit & Push
         run: |

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -2,7 +2,7 @@ name: Update GitHub metrics
 
 on:
   schedule:
-    - cron: "23 6 * * *"  # daily at 06:23 UTC
+    - cron: "23 6 * * 0"  # weekly on Sunday at 06:23 UTC
   workflow_dispatch:
 
 permissions:
@@ -22,7 +22,8 @@ jobs:
       - name: Generate metrics
         uses: lowlighter/metrics@v3.34
         with:
-          token: ${{ github.token }}
+          # Prefer the PAT secret so metrics can include private activity.
+          token: ${{ secrets.METRICS_TOKEN || github.token }}
           user: Jason-Latz
           template: classic
           base: header, activity, community, repositories, metadata

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -2,7 +2,7 @@ name: Update GitHub metrics
 
 on:
   schedule:
-    - cron: "23 6 * * 0"  # weekly on Sunday at 06:23 UTC
+    - cron: "23 6 * * *"  # daily at 06:23 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/recent-activity.yml
+++ b/.github/workflows/recent-activity.yml
@@ -3,7 +3,7 @@ name: Update recent activity
 
 'on':
   schedule:
-    - cron: "31 6 * * *"  # daily at 06:31 UTC
+    - cron: "31 6 * * 0"  # weekly on Sunday at 06:31 UTC
   workflow_dispatch:
 
 permissions:
@@ -22,7 +22,8 @@ jobs:
           GH_USERNAME: Jason-Latz
           CONFIG_FILE: .github/recent-activity.config.yml
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # Use the PAT secret when available so private activity can be included.
+          GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}
 
       - name: Commit and push
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/recent-activity.yml
+++ b/.github/workflows/recent-activity.yml
@@ -3,7 +3,7 @@ name: Update recent activity
 
 'on':
   schedule:
-    - cron: "31 6 * * 0"  # weekly on Sunday at 06:31 UTC
+    - cron: "31 6 * * *"  # daily at 06:31 UTC
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://github.com/Jason-Latz">
-    <img src="https://img.shields.io/github/followers/Jason-Latz?label=Follow&style=social" alt="GitHub Followers" />
+    <img src="https://img.shields.io/badge/GitHub-Jason--Latz-181717?logo=github&style=flat" alt="GitHub Profile" />
   </a>
   <a href="https://www.linkedin.com/in/jason-latz-7b8634242/">
     <img src="https://img.shields.io/badge/LinkedIn-Connect-blue?logo=linkedin&style=flat" alt="LinkedIn" />
@@ -34,6 +34,9 @@ I'm a Northwestern student studying Computer Science and Psychology! After worki
 
 ---
 
+## 📌 Recent GitHub Activity
+<!--RECENT_ACTIVITY:start-->
+<!--RECENT_ACTIVITY:end-->
 
 ---
 


### PR DESCRIPTION
## Summary
- restore the profile automation workflows to daily runs
- keep the PAT-backed token preference for private-activity capable jobs
- restore the `RECENT_ACTIVITY` markers that `Readme-Workflows/recent-activity` expects on `main`
- replace the broken GitHub followers badge with a static GitHub profile badge that does not depend on Shields' GitHub token pool

## What changed
- switched `.github/workflows/recent-activity.yml` back to daily at `06:31 UTC`
- switched `.github/workflows/metrics.yml` back to daily at `06:23 UTC`
- switched `.github/workflows/activity-graph.yml` back to daily at `18:00 UTC`
- kept `METRICS_TOKEN` as the preferred secret for the workflow actions, with `${{ github.token }}` as fallback
- restored the `<!--RECENT_ACTIVITY:start-->` / `<!--RECENT_ACTIVITY:end-->` comments in `README.md`
- replaced the top GitHub followers badge after confirming the old `img.shields.io/github/followers/...` URL currently renders `Unable to select next GitHub token from pool`

## Validation
- parsed all three workflow YAML files with Ruby `YAML.load_file`
- confirmed the new static GitHub badge URL renders a normal SVG response
- confirmed the README now contains the expected `RECENT_ACTIVITY` markers
- inspected recent GitHub Actions runs and verified the recurring failure was `Couldn't find the <!--RECENT_ACTIVITY:start--> comment. Exiting!`
- restored the local Codex `update-github` automation cadence to daily, with next run at `2026-06-11T09:00:00-05:00`

## Notes
- PR #9 is still open with the narrower marker-only fix, but this branch now includes that repair along with the daily cadence and badge fix.
